### PR TITLE
Grant permission to access Waydroid's icons

### DIFF
--- a/io.github.fabrialberio.pinapp.yml
+++ b/io.github.fabrialberio.pinapp.yml
@@ -15,6 +15,9 @@ finish-args:
   - --filesystem=/var/lib/flatpak:ro
   - --filesystem=/var/lib/snapd:ro
 
+  # Waydroid's icons
+  - --filesystem=xdg-data/waydroid/data/icons:ro
+
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
Waydroid puts its icons in a separate directory (i.e. "xdg-data/waydroid/data/icons"). Grant read-only access to this directory, so users don't need to do so manually.

Thanks for developing PinApp! 📍❤️  