### PR TITLE
Use GNOME runtime 46 and remove unneeded modules

### DIFF
--- a/io.github.fabrialberio.pinapp.yml
+++ b/io.github.fabrialberio.pinapp.yml
@@ -10,8 +10,8 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
 
-  - --filesystem=xdg-data/applications:rw
-  - --filesystem=xdg-data/flatpak:ro
+  - --filesystem=~/.local/share/applications:rw
+  - --filesystem=~/.local/share/flatpak:ro
   - --filesystem=/var/lib/flatpak:ro
   - --filesystem=/var/lib/snapd:ro
 

--- a/io.github.fabrialberio.pinapp.yml
+++ b/io.github.fabrialberio.pinapp.yml
@@ -23,3 +23,5 @@ modules:
   - type: git
     url: https://github.com/fabrialberio/pinapp
     tag: "v1.2.0"
+  - type: patch
+    path: metadata.patch

--- a/io.github.fabrialberio.pinapp.yml
+++ b/io.github.fabrialberio.pinapp.yml
@@ -1,7 +1,7 @@
 id: io.github.fabrialberio.pinapp
 sdk: org.gnome.Sdk
 runtime: org.gnome.Platform
-runtime-version: "44"
+runtime-version: "46"
 command: pinapp
 
 finish-args:
@@ -15,92 +15,7 @@ finish-args:
   - --filesystem=/var/lib/flatpak:ro
   - --filesystem=/var/lib/snapd:ro
 
-cleanup:
-  - /include
-  - /lib/pkgconfig
-  - /man
-  - /share/doc
-  - /share/gtk-doc
-  - /share/man
-  - /share/pkgconfig
-  - "*.la"
-  - "*.a"
-
 modules:
-- name: libyaml
-  buildsystem: autotools
-  builddir: true
-  config-opts:
-  - --libdir=/app/lib
-  sources:
-  - type: git
-    url: https://github.com/yaml/libyaml
-    tag: "0.2.5"
-- name: libxmlb
-  buildsystem: meson
-  config-opts:
-  - -Dgtkdoc=false
-  sources:
-  - type: git
-    url: https://github.com/hughsie/libxmlb.git
-    tag: "0.3.14"
-- name: appstream
-  buildsystem: meson
-  config-opts:
-  - -Dstemming=false
-  - -Dapidocs=false
-  sources:
-  - type: git
-    url: https://github.com/ximion/appstream.git
-    tag: v0.15.2
-    commit: d2bfe7c2a4ca692daf33a5cb4d429011269d1cba
-- name: gtk4
-  buildsystem: meson
-  config-opts: []
-  sources:
-  - type: git
-    url: https://gitlab.gnome.org/GNOME/gtk.git
-    tag: "4.11.3"
-  modules:
-  - name: libsass
-    buildsystem: meson
-    sources:
-    - type: git
-      url: https://github.com/lazka/libsass.git
-      branch: meson
-      commit: aac79dccd3c8f7e8f22125f87a119f3b1ee9d487
-  - name: sassc
-    buildsystem: meson
-    sources:
-    - type: git
-      url: https://github.com/lazka/sassc.git
-      branch: meson
-      commit: a1950c2d95ea4c051feb90bb1f43559fbb54bf36
-- name: libadwaita
-  buildsystem: meson
-  config-opts:
-  - -Dexamples=false
-  - -Dtests=false
-  sources:
-  - type: git
-    url: https://gitlab.gnome.org/GNOME/libadwaita.git
-    tag: "1.4.rc"
-  modules:
-  - name: libsass
-    buildsystem: meson
-    sources:
-    - type: git
-      url: https://github.com/lazka/libsass.git
-      branch: meson
-      commit: aac79dccd3c8f7e8f22125f87a119f3b1ee9d487
-  - name: sassc
-    buildsystem: meson
-    sources:
-    - type: git
-      url: https://github.com/lazka/sassc.git
-      branch: meson
-      commit: a1950c2d95ea4c051feb90bb1f43559fbb54bf36
-
 - name: PinApp
   builddir: true
   buildsystem: meson

--- a/metadata.patch
+++ b/metadata.patch
@@ -1,0 +1,35 @@
+diff --git a/data/io.github.fabrialberio.pinapp.appdata.xml.in b/data/io.github.fabrialberio.pinapp.appdata.xml.in
+index 80a38b1..88739a3 100644
+--- a/data/io.github.fabrialberio.pinapp.appdata.xml.in
++++ b/data/io.github.fabrialberio.pinapp.appdata.xml.in
+@@ -1,13 +1,14 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <component type="desktop">
+ 	<id>io.github.fabrialberio.pinapp</id>
+-	<launchable type="desktop-id">io.github.fabrialberio.pinapp.desktop</launchable>	<name translatable='no'>PinApp</name>
++	<launchable type="desktop-id">io.github.fabrialberio.pinapp.desktop</launchable>
++	<translation type="gettext">pinapp</translation>
++	<name translatable="no">PinApp</name>
+ 	<metadata_license>CC0-1.0</metadata_license>
+ 	<project_license>GPL-3.0-or-later</project_license>
+-	<name translatable='no'>PinApp</name>
+-	<summary translatable='yes'>Create and edit application shortcuts</summary>
++	<summary>Create and edit app shortcuts</summary>
+     <developer_name translatable="no">Fabrizio Alberio</developer_name>
+-	<description translatable='yes'>
++	<description>
+ 		<p>PinApp is a simple application that lets you customize your app list.</p>
+ 		<p>Some of the possible uses are</p>
+ 		<ul>
+diff --git a/data/io.github.fabrialberio.pinapp.desktop.in b/data/io.github.fabrialberio.pinapp.desktop.in
+index f5b8956..2cc14e1 100644
+--- a/data/io.github.fabrialberio.pinapp.desktop.in
++++ b/data/io.github.fabrialberio.pinapp.desktop.in
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Name=PinApp
+-Comment=Create and edit application shortcuts
++Comment=Create and edit app shortcuts
+ Exec=pinapp %u
+ MimeType=application/x-desktop;
+ Icon=io.github.fabrialberio.pinapp


### PR DESCRIPTION
The dependencies previously built are now included in the runtime.

Contains the bare minimum changes to get past the linter.